### PR TITLE
Properties validation failed for resource CentralConfigBucket with me…

### DIFF
--- a/securitystack-singleaccount-production.yaml
+++ b/securitystack-singleaccount-production.yaml
@@ -45,28 +45,27 @@ Resources:
         BlockPublicPolicy: true
         RestrictPublicBuckets: true
       LifecycleConfiguration:
-        Rules:
-          - Id: MoveToIA30Days
-            Status: Enabled
-            Prefix: ""
-            Transition:
-              - StorageClass: STANDARD_IA
-                TransitionInDays: 30
-            NoncurrentVersionTransitions:
-              - StorageClass: STANDARD_IA
-                NoncurrentDays: 30
-            NoncurrentVersionExpirationInDays: 3650
-          - Id: MoveToGlacier365Days
-            Status: Enabled
-            Prefix: ""
-            Transition:
-              - StorageClass: GLACIER
-                TransitionInDays: 365
-          - Id: ExpireAfter7Years
-            Status: Enabled
-            Prefix: ""
-            ExpirationInDays: 2555
-    DeletionPolicy: Retain
+  Rules:
+    - Id: MoveToIA30Days
+      Status: Enabled
+      Prefix: ""
+      Transition:
+        StorageClass: STANDARD_IA
+        TransitionInDays: 30
+      NoncurrentVersionTransitions:
+        - StorageClass: STANDARD_IA
+          NoncurrentDays: 30
+    - Id: MoveToGlacier365Days
+      Status: Enabled
+      Prefix: ""
+      Transition:
+        StorageClass: GLACIER
+        TransitionInDays: 365
+    - Id: ExpireAfter7Years
+      Status: Enabled
+      Prefix: ""
+      ExpirationInDays: 2555
+  DeletionPolicy: Retain
 
   # Minimal bucket policy allowing AWS Config service in THIS account/region to put objects
   CentralBucketPolicy:


### PR DESCRIPTION
…ssage: [#/LifecycleConfiguration/Rules/1/Transition: expected type: JSONObject, found: JSONArray, #/LifecycleConfiguration/Rules/0/Transition: expected type: JSONObject, found: JSONArray, #/LifecycleConfiguration/Rules/0/NoncurrentVersionTransitions/0: extraneous key [NoncurrentDays] is not permitted]