### PR TITLE
Properties validation failed for resource CentralConfigBucket with me…

### DIFF
--- a/securitystack-singleaccount-production.yaml
+++ b/securitystack-singleaccount-production.yaml
@@ -53,7 +53,7 @@ Resources:
               StorageClass: STANDARD_IA
               TransitionInDays: 30
             NoncurrentVersionTransitions:
-              - StorageClass: STANDARD_IA
+                StorageClass: STANDARD_IA
                 NoncurrentDays: 30
           - Id: MoveToGlacier365Days
             Status: Enabled


### PR DESCRIPTION
…ssage: [#/LifecycleConfiguration/Rules/0/NoncurrentVersionTransitions/0: extraneous key [NoncurrentDays] is not permitted]