### PR TITLE
Insufficient delivery policy to s3 bucket: securitystack-config-upgra…

### DIFF
--- a/securitystack-singleaccount-production.yaml
+++ b/securitystack-singleaccount-production.yaml
@@ -86,6 +86,16 @@ Resources:
               StringEquals:
                 aws:SourceAccount: !Sub "${AWS::AccountId}"
 
+          - Sid: AllowConfigGetBucketAcl
+            Effect: Allow
+            Principal:
+              Service: config.amazonaws.com
+            Action: s3:GetBucketAcl
+            Resource: !GetAtt CentralConfigBucket.Arn
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Sub "${AWS::AccountId}"
+
           - Sid: AllowConfigGetBucketLocation
             Effect: Allow
             Principal:


### PR DESCRIPTION
…ded-dollop, unable to get s3 bucket acl. (Service: AmazonConfig; Status Code: 400; Error Code: InsufficientDeliveryPolicyException; Request ID: 161f7dae-0eed-45af-9bae-cf1cf4fe7dd9; Proxy: null)